### PR TITLE
Add & move queue logic to `libs`

### DIFF
--- a/go.work
+++ b/go.work
@@ -3,4 +3,5 @@ go 1.23.0
 use (
 	./apps/notification
 	./apps/server
+	./libs/queue
 )

--- a/libs/queue/config.go
+++ b/libs/queue/config.go
@@ -1,0 +1,31 @@
+package broker
+
+import (
+	"github.com/joho/godotenv"
+	"github.com/kelseyhightower/envconfig"
+	"os"
+	"path/filepath"
+)
+
+type Config struct {
+	Url string `envconfig:"RABBITMQ_URL" required:"true"`
+}
+
+func NewConfig() (Config, error) {
+	cfg := Config{}
+
+	wd, err := os.Getwd()
+	if err != nil {
+		return cfg, err
+	}
+
+	envPath := filepath.Join(wd, ".env")
+
+	_ = godotenv.Load(envPath)
+
+	if err := envconfig.Process("", &cfg); err != nil {
+		return cfg, err
+	}
+
+	return cfg, nil
+}

--- a/libs/queue/go.mod
+++ b/libs/queue/go.mod
@@ -1,0 +1,10 @@
+module github.com/taskemapp/server/libs/queue
+
+go 1.23.0
+
+require (
+	github.com/joho/godotenv v1.5.1
+	github.com/kelseyhightower/envconfig v1.4.0
+	github.com/pkg/errors v0.9.1
+	github.com/rabbitmq/amqp091-go v1.10.0
+)

--- a/libs/queue/go.sum
+++ b/libs/queue/go.sum
@@ -1,0 +1,10 @@
+github.com/joho/godotenv v1.5.1 h1:7eLL/+HRGLY0ldzfGMeQkb7vMd0as4CfYvUVzLqw0N0=
+github.com/joho/godotenv v1.5.1/go.mod h1:f4LDr5Voq0i2e/R5DDNOoa2zzDfwtkZa6DnEwAbqwq4=
+github.com/kelseyhightower/envconfig v1.4.0 h1:Im6hONhd3pLkfDFsbRgu68RDNkGF1r3dvMUtDTo2cv8=
+github.com/kelseyhightower/envconfig v1.4.0/go.mod h1:cccZRl6mQpaq41TPp5QxidR+Sa3axMbJDNb//FQX6Gg=
+github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=
+github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
+github.com/rabbitmq/amqp091-go v1.10.0 h1:STpn5XsHlHGcecLmMFCtg7mqq0RnD+zFr4uzukfVhBw=
+github.com/rabbitmq/amqp091-go v1.10.0/go.mod h1:Hy4jKW5kQART1u+JkDTF9YYOQUHXqMuhrgxOEeS7G4o=
+go.uber.org/goleak v1.3.0 h1:2K3zAYmnTNqV73imy9J1T3WC+gmCePx2hEGkimedGto=
+go.uber.org/goleak v1.3.0/go.mod h1:CoHD4mav9JJNrW/WLlf7HGZPjdw8EucARQHekz1X6bE=

--- a/libs/queue/mq.go
+++ b/libs/queue/mq.go
@@ -1,0 +1,108 @@
+package broker
+
+import (
+	"context"
+	"github.com/pkg/errors"
+	amqp "github.com/rabbitmq/amqp091-go"
+	"time"
+)
+
+type RabbitMQ struct {
+	conn *amqp.Connection
+	c    Config
+}
+
+func NewMQ(conn *amqp.Connection, c Config) *RabbitMQ {
+	return &RabbitMQ{conn: conn, c: c}
+}
+
+func (r *RabbitMQ) Consume(name string, handler ConsumeFn) error {
+	ch, err := r.conn.Channel()
+	if err != nil {
+		return err
+	}
+	defer ch.Close()
+
+	q, err := ch.QueueDeclare(
+		name,
+		false,
+		false,
+		false,
+		false,
+		nil,
+	)
+	if err != nil {
+		return errors.Wrap(err, "Failed to declare a queue")
+	}
+
+	consumer, err := ch.Consume(
+		q.Name,
+		"notifi",
+		true,
+		false,
+		false,
+		false,
+		nil,
+	)
+
+	if err != nil {
+		return errors.Wrap(err, "Failed to consume")
+	}
+
+	out := make(chan Message)
+	go func() {
+		defer close(out)
+		for msg := range consumer {
+			println("cast msg: ", msg.Body)
+			out <- Message{
+				ContentType: msg.ContentType,
+				Body:        msg.Body,
+			}
+		}
+	}()
+
+	return handler(out)
+}
+
+func (r *RabbitMQ) Close() error {
+	return r.conn.Close()
+}
+
+func (r *RabbitMQ) Publish(queue string, message Message) error {
+	ch, err := r.conn.Channel()
+	if err != nil {
+		return err
+	}
+	defer ch.Close()
+
+	q, err := ch.QueueDeclare(
+		queue,
+		false,
+		false,
+		false,
+		false,
+		nil,
+	)
+	if err != nil {
+		return errors.Wrap(err, "Failed to declare a queue")
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	err = ch.PublishWithContext(
+		ctx,
+		"",
+		q.Name,
+		false,
+		false,
+		amqp.Publishing{
+			ContentType: message.ContentType,
+			Timestamp:   time.Now(),
+			Body:        message.Body,
+		})
+	if err != nil {
+		return errors.Wrap(err, "Failed to publish a message")
+	}
+
+	return nil
+}

--- a/libs/queue/queue.go
+++ b/libs/queue/queue.go
@@ -1,0 +1,14 @@
+package broker
+
+type ConsumeFn func(<-chan Message) error
+
+type Queue interface {
+	Publish(queue string, message Message) error
+	Consume(name string, handler ConsumeFn) error
+	Close() error
+}
+
+type Message struct {
+	ContentType string
+	Body        []byte
+}


### PR DESCRIPTION
Now, the general message broker's business logic is contained in libs/queue